### PR TITLE
Fix issue of normal user run tensorflow workloads

### DIFF
--- a/Spectrum LSF Application Center/TensorflowImage/submission_templates/Classify_Directory_Of_Images/Classify_Directory_Of_Images.cmd
+++ b/Spectrum LSF Application Center/TensorflowImage/submission_templates/Classify_Directory_Of_Images/Classify_Directory_Of_Images.cmd
@@ -188,6 +188,7 @@ elif [ "x$RUNLIMITMINUTE" != "x" ]; then
 fi
 
 CWD_OPT="-cwd \"$OUTPUT_FILE_LOCATION\""
+chmod a+w+r $OUTPUT_FILE_LOCATION
 
 #echo "bsub ${LSF_OPT} ${ADVANCED_OPT} ${LIMITS_OPT} ${CUSTOMIZE_OPT} ${JOB_COMMAND}" >> /tmp/aaa
 JOB_RESULT=`/bin/sh -c "bsub ${CWD_OPT} ${LSF_OPT} ${ADVANCED_OPT} ${LIMITS_OPT} ${CUSTOMIZE_OPT} ${JOB_COMMAND} ${OTHER_OPT} 2>&1"`

--- a/Spectrum LSF Application Center/TensorflowImage/submission_templates/Classify_Image/Classify_Image.cmd
+++ b/Spectrum LSF Application Center/TensorflowImage/submission_templates/Classify_Image/Classify_Image.cmd
@@ -213,6 +213,7 @@ elif [ "x$RUNLIMITMINUTE" != "x" ]; then
 fi
 
 CWD_OPT="-cwd \"$OUTPUT_FILE_LOCATION\""
+chmod a+w+r $OUTPUT_FILE_LOCATION
 
 #echo "bsub ${LSF_OPT} ${ADVANCED_OPT} ${LIMITS_OPT} ${CUSTOMIZE_OPT} ${JOB_COMMAND}" >> /tmp/aaa
 #env > /tmp/pac_$$.txt 2>&1

--- a/Spectrum LSF Application Center/TensorflowImage/submission_templates/MNIST_Training/MNIST_Training.cmd
+++ b/Spectrum LSF Application Center/TensorflowImage/submission_templates/MNIST_Training/MNIST_Training.cmd
@@ -187,6 +187,7 @@ elif [ "x$RUNLIMITMINUTE" != "x" ]; then
 fi
 
 CWD_OPT="-cwd \"$OUTPUT_FILE_LOCATION\""
+chmod a+w+r $OUTPUT_FILE_LOCATION
 
 #echo "bsub ${LSF_OPT} ${ADVANCED_OPT} ${LIMITS_OPT} ${CUSTOMIZE_OPT} ${JOB_COMMAND}" >> /tmp/aaa
 JOB_RESULT=`/bin/sh -c "bsub ${CWD_OPT} ${LSF_OPT} ${ADVANCED_OPT} ${LIMITS_OPT} ${CUSTOMIZE_OPT} ${JOB_COMMAND} ${OTHER_OPT} 2>&1"`

--- a/Spectrum LSF Application Center/TensorflowImage/submission_templates/Retrain_Model/Retrain_Model.cmd
+++ b/Spectrum LSF Application Center/TensorflowImage/submission_templates/Retrain_Model/Retrain_Model.cmd
@@ -182,6 +182,7 @@ elif [ "x$RUNLIMITMINUTE" != "x" ]; then
 fi
 
 CWD_OPT="-cwd \"$OUTPUT_FILE_LOCATION\""
+chmod a+w+r $OUTPUT_FILE_LOCATION
 
 #echo "bsub ${LSF_OPT} ${ADVANCED_OPT} ${LIMITS_OPT} ${CUSTOMIZE_OPT} ${JOB_COMMAND}" >> /tmp/aaa
 JOB_RESULT=`/bin/sh -c "bsub ${CWD_OPT} ${LSF_OPT} ${ADVANCED_OPT} ${LIMITS_OPT} ${CUSTOMIZE_OPT} ${JOB_COMMAND} ${OTHER_OPT} 2>&1"`

--- a/Spectrum LSF Application Center/TensorflowImage/submission_templates/Tensorboard/Tensorboard.cmd
+++ b/Spectrum LSF Application Center/TensorflowImage/submission_templates/Tensorboard/Tensorboard.cmd
@@ -182,6 +182,7 @@ elif [ "x$RUNLIMITMINUTE" != "x" ]; then
 fi
 
 CWD_OPT="-cwd \"$OUTPUT_FILE_LOCATION\""
+chmod a+w+r $OUTPUT_FILE_LOCATION
 
 JOB_RESULT=`/bin/sh -c "bsub ${CWD_OPT} ${LSF_OPT} ${ADVANCED_OPT} ${LIMITS_OPT} ${CUSTOMIZE_OPT} ${JOB_COMMAND} ${OTHER_OPT} 2>&1"`
 


### PR DESCRIPTION
**What this PR does / why we need it:**
Fix issue below

**Issue:** run tensorflow jobs by normal user (non LSF Primary Admin), will be error report as below:
```
/home/fengli/mldl_top/scripts/dockerPasswd.sh: line 41: /home/fengli/Classify_Image_1557399392392TheKL/.passwd.164.0: Permission denied
/home/fengli/mldl_top/scripts/dockerPasswd.sh: line 42: /home/fengli/Classify_Image_1557399392392TheKL/.group.164.0: Permission denied
/home/fengli/mldl_top/scripts/dockerPasswd.sh: line 52: /home/fengli/Classify_Image_1557399392392TheKL/.passwd.164.0: Permission denied
/home/fengli/mldl_top/scripts/dockerPasswd.sh: line 66: /home/fengli/Classify_Image_1557399392392TheKL/.group.164.0: Permission denied
/home/fengli/mldl_top/scripts/dockerPasswd.sh: line 66: /home/fengli/Classify_Image_1557399392392TheKL/.group.164.0: Permission denied
/home/fengli/mldl_top/scripts/dockerPasswd.sh: line 66: /home/fengli/Classify_Image_1557399392392TheKL/.group.164.0: Permission denied
chmod: cannot access ‘/home/fengli/Classify_Image_1557399392392TheKL/.passwd.164.0’: No such file or directory
chmod: cannot access ‘/home/fengli/Classify_Image_1557399392392TheKL/.group.164.0’: No such file or directory
```
**Expect result:** run tensorflow jobs by normal user successfully
**Root Cause:**  dockerPasswd.sh was exec by LSF Primary Admin, and will write files to CWD/OUTPUT_FILE_LOCATION. But LSF Primary Admin has no write permission if the workloads are ran by LSF Non-Primary Admin user.

**Fix Solution:** Provide write permission to OUTPUT_FILE_LOCATION.

Pls mail me or append your concern here if any issues, Thanks. 

@fenglixa fenglixa@cn.ibm.com