### PR TITLE
Use items instead of iteritems for python3

### DIFF
--- a/Spectrum LSF Application Center/pacclient/pac_api.py
+++ b/Spectrum LSF Application Center/pacclient/pac_api.py
@@ -1839,7 +1839,7 @@ def getPseudoFlowInstances(flowid, flowname, username, flowstate):
 	url_flows = url + 'ws/flow/instances'
 	args = {"id":flowid, "flowname":flowname, "username":username, "state":flowstate}
 	first = True
-	for key, val in args.iteritems():
+	for key, val in args.items():
 		if not val:
 			continue
 		if first:


### PR DESCRIPTION
iteritems is expired in python3 and use items instead.