### PR TITLE
fix to get job details by username

### DIFF
--- a/Spectrum LSF Application Center/pacclient/pac_api.py
+++ b/Spectrum LSF Application Center/pacclient/pac_api.py
@@ -20,7 +20,8 @@ PACCONTEXT='platform'
 PACPASSFILE='.pacpass'
 ACCEPT_TYPE='text/plain,application/xml,text/xml,multipart/mixed'
 ERROR_STR='errMsg'
-NOTE_STR='note'
+#After fix this should be treated as TAG
+NOTE_STR='<' +'note' +'>'
 ERROR_TAG='<' + ERROR_STR + '>'
 ACTION_STR='actionMsg'
 ACTION_TAG='<' + ACTION_STR + '>'
@@ -753,7 +754,7 @@ def getJobListInfo(parameter):
 			if ERROR_TAG in content:
 				err=xdoc.find(ERROR_STR)
 				return 'error', err.text
-			elif NOTE_STR in content:
+			elif xdoc.find(NOTE_STR):
 				err=xdoc.find(NOTE_STR)
 				return 'error', err.text
 			else:


### PR DESCRIPTION
pacclient was failing when the user command had the word "notebook" or "note", this fix now enables to get jobs by username with user command that has note* in it.