### PR TITLE
Unable to login with cacert.pem file

### DIFF
--- a/Spectrum LSF Application Center/pacclient/pac_api.py
+++ b/Spectrum LSF Application Center/pacclient/pac_api.py
@@ -1566,7 +1566,7 @@ def getHttp(url,x509Flag):
 
 	#If the file exists and SSL Handshake is required(httplib2 version is 0.7+)
 	if ( (len(pemFile) > 0) & (sslHandshakeRequiredFlag == True) ):
-		http = httplib2.Http(ca_certs=pemFile, disable_ssl_certificate_validation=True)
+		http = httplib2.Http(ca_certs=pemFile, disable_ssl_certificate_validation=False)
 	else:
 		http = httplib2.Http()
 	return http


### PR DESCRIPTION
This is due to the fact that verification of the key is disabled causing the following errors:

```bash
  File "./pacclient.py", line 1369, in <module>
    main(sys.argv[1:])
  File "./pacclient.py", line 1288, in main
    main_logon(argv[1:])
  File "./pacclient.py", line 81, in main_logon
    logon(url, user, password)
  File "/root/lsf-integrations/Spectrum LSF Application Center/pacclient/pac_api.py", line 642, in logon
    response, contentb = http.request(url_logon, 'GET', body=body, headers=headers)
  File "/usr/local/lib/python3.6/site-packages/httplib2/__init__.py", line 1588, in request
    tls_minimum_version=self.tls_minimum_version,
  File "/usr/local/lib/python3.6/site-packages/httplib2/__init__.py", line 1103, in __init__
    key_password=key_password,
  File "/usr/local/lib/python3.6/site-packages/httplib2/__init__.py", line 155, in _build_ssl_context
    context.verify_mode = ssl.CERT_NONE if disable_ssl_certificate_validation else ssl.CERT_REQUIRED
  File "/usr/lib64/python3.6/ssl.py", line 443, in verify_mode
    super(SSLContext, SSLContext).verify_mode.__set__(self, value)
ValueError: Cannot set verify_mode to CERT_NONE when check_hostname is enabled.
```

Signed-Off: cacti@qualcomm.com